### PR TITLE
table: decide on array interface when necessary

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1482,6 +1482,10 @@ class Table(Sequence, Storage):
         """
         return any(sp.issparse(i) for i in [self._X, self._Y, self._metas])
 
+    def is_dask_table(self):
+        # TODO: check metas when we decide on what we will do with them
+        return isinstance(self.X, da.Array) and isinstance(self.Y, da.Array)
+
     def ensure_copy(self):
         """
         Ensure that the table owns its data; copy arrays when necessary.
@@ -1730,10 +1734,11 @@ class Table(Sequence, Storage):
             conditions = [filter]
             conjunction = True
 
+        _array_interface = da if self.is_dask_table() else np
         if conjunction:
-            sel = da.ones(len(self), dtype=bool)
+            sel = _array_interface.ones(len(self), dtype=bool)
         else:
-            sel = da.zeros(len(self), dtype=bool)
+            sel = _array_interface.zeros(len(self), dtype=bool)
 
         for f in conditions:
             selection = self._filter_to_indicator(f)
@@ -1813,7 +1818,8 @@ class Table(Sequence, Storage):
         if len(col_indices) == 1:
             sel = col_filter(col_indices[0])
         else:
-            sel = da.ones(len(self), dtype=bool)
+            _array_interface = da if self.is_dask_table() else np
+            sel = _array_interface.ones(len(self), dtype=bool)
             for col_idx in col_indices:
                 sel *= col_filter(col_idx)
 
@@ -1837,7 +1843,8 @@ class Table(Sequence, Storage):
             col = col.astype(float)
             return ~np.isnan(col)
 
-        sel = da.zeros(len(self), dtype=bool)
+        _array_interface = da if self.is_dask_table() else np
+        sel = _array_interface.zeros(len(self), dtype=bool)
         for val in filter.values:
             if not isinstance(val, Real):
                 val = self.domain[filter.column].to_val(val)


### PR DESCRIPTION
##### Issue
Some operations fail when mixing numpy and dask arrays. e.g.:

```
line 1744, in _values_filter_to_indicator
    sel *= selection
line 1581, in __array_ufunc__
    return elemwise(numpy_ufunc, *inputs, **kwargs)
line 4635, in elemwise
    out = _elemwise_normalize_out(out)
line 4735, in _elemwise_normalize_out
    raise NotImplementedError(
NotImplementedError: The out parameter is not fully supported. Received type ndarray, expected Dask Array
```

##### Description of changes

Check Table.X and .Y types and choose the correct array interface (Dask or NumPy) when necessary.

This is not necessarily the best solution. This could also be determined upon class initialization.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
