### PR TITLE
state_summary: fix formatting in tests

### DIFF
--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -18,7 +18,7 @@ from Orange.widgets.utils.signals import AttributeList
 from Orange.base import Model, Learner
 
 
-SIZE_LIMIT = 1e7
+COMPUTE_NANS_LIMIT = 1e7
 
 
 def format_variables_string(variables):
@@ -85,7 +85,7 @@ def format_summary_details(data, format=Qt.PlainText):
     metas = format_variables_string(data.domain.metas)
 
     features_missing = ""
-    if data.X.size < SIZE_LIMIT:
+    if data.X.size < COMPUTE_NANS_LIMIT:
         features_missing = missing_values(data.get_nan_frequency_attribute())
     n_features = len(data.domain.variables) + len(data.domain.metas)
     name = getattr(data, "name", None)

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -185,7 +185,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(details, format_summary_details(data))
 
         data = Table.from_numpy(domain=None, X=np.random.random((10000, 1000)))
-        details = f'{len(data)} instances, ' \
+        details = f'{len(data):n} instances, ' \
                   f'{len(data.domain.variables)} variables\n' \
                   f'Features: {len(data.domain.variables)} numeric \n' \
                   f'Target: —'


### PR DESCRIPTION
Fixes formatting in state summary (error was introduced when preparing summary for large tables).